### PR TITLE
fix: x not working

### DIFF
--- a/_data-portal/app/population/population-home.component.ts
+++ b/_data-portal/app/population/population-home.component.ts
@@ -131,11 +131,11 @@ export class PopulationHomeComponent extends FilterBuilderBase<'dc' | 'ag', Filt
   removeTokenFromFilters(token: FilterToken) {
     if (token.type === 'dc') {
       this.dcFilters[token.key] = false;
-      this.onDcFiltersChange(this.dcFilters);
+      this.onDcFiltersChange({ filters: this.dcFilters, code: token.key, isFiltered: false });
       return;
     }
     this.agFilters[token.key] = false;
-    this.onAgFiltersChange(this.agFilters);
+    this.onAgFiltersChange({ filters: this.agFilters, code: token.key, isFiltered: false });
   }
 
   protected createToken(type: 'dc' | 'ag', key: string, id: string): FilterToken {

--- a/_data-portal/app/sample/sample-home.component.ts
+++ b/_data-portal/app/sample/sample-home.component.ts
@@ -179,16 +179,16 @@ export class SampleHomeComponent extends FilterBuilderBase<'pop' | 'dc' | 'ag', 
   removeTokenFromFilters(token: FilterToken) {
     if (token.type === 'pop') {
       this.popFilters[token.key] = false;
-      this.onPopFiltersChange(this.popFilters);
+      this.onPopFiltersChange({ filters: this.popFilters, code: token.key, isFiltered: false });
       return;
     }
     if (token.type === 'dc') {
       this.dcFilters[token.key] = false;
-      this.onDcFiltersChange(this.dcFilters);
+      this.onDcFiltersChange({ filters: this.dcFilters, code: token.key, isFiltered: false });
       return;
     }
     this.agFilters[token.key] = false;
-    this.onAgFiltersChange(this.agFilters);
+    this.onAgFiltersChange({ filters: this.agFilters, code: token.key, isFiltered: false });
   }
 
   protected createToken(type: 'pop' | 'dc' | 'ag', key: string, id: string): FilterToken {


### PR DESCRIPTION
This PR applies a fix to the 'Filtration query builder'. Currently on test and prod, the 'x' on individual filter chips isn't working, i.e. clicking the 'x' doesn't remove the chip. 

<img width="281" height="45" alt="Screenshot 2026-05-06 at 11 36 53" src="https://github.com/user-attachments/assets/55f65e67-8358-48fb-9f8d-98e4488af173" />

This is because the filter-change functions were expecting additional args: `code` and `isFiltered`. I have added a tiny fix so that these args are supplied, and in local testing, the 'x' button now removes the chip. 