### PR TITLE
Add API section to help page

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -14,6 +14,13 @@ server {
   # Redirect /data-portal -> /data-portal/
   location = /data-portal { return 301 /data-portal/$is_args$args; }
 
+  # FastAPI documentation is served by igsr-be via the /api/ proxy
+  location = /docs { return 301 /api/docs$is_args$args; }
+  location = /docs/ { return 301 /api/docs$is_args$args; }
+  location = /redoc { return 301 /api/redoc$is_args$args; }
+  location = /redoc/ { return 301 /api/redoc$is_args$args; }
+  location = /openapi.json { return 301 /api/openapi.json$is_args$args; }
+
   # Angular portal (SPA)
   location /data-portal/ { try_files $uri $uri/ /data-portal/index.html; }
 

--- a/help.md
+++ b/help.md
@@ -4,12 +4,16 @@ title: "Help"
 permalink: /help/
 tags: Help
 redirect_from:
- - /contact/
+  - /contact/
 ---
 
 #[FAQs](/faq)
 
 We have an extensive set of [Frequently Asked Questions](/faq) which may have the information you are looking for. Please take a look to see if they answer your question.
+
+#[API](/docs)
+
+You can use the public IGSR API to query samples, populations, data collections, analysis groups and files. See the [APIdocumentation](/docs) for available endpoints and example requests.
 
 #[Downloading data](/data#download)
 

--- a/help.md
+++ b/help.md
@@ -13,7 +13,7 @@ We have an extensive set of [Frequently Asked Questions](/faq) which may have th
 
 #[API](/docs)
 
-You can use the public IGSR API to query samples, populations, data collections, analysis groups and files. See the [APIdocumentation](/docs) for available endpoints and example requests.
+You can use the public IGSR API to query samples, populations, data collections, analysis groups and files. See the [API documentation](/docs) for available endpoints and example requests.
 
 #[Downloading data](/data#download)
 


### PR DESCRIPTION
See IGSR-643.

## Description

This PR adds a help section for the public API, as well as relevant nginx redirects. 
Linked to https://github.com/igsr/igsr-be/pull/15.

## Testing

See this on the test site: https://test.internationalgenome.org/help/.