### PR TITLE
Add filtration query builder announcement

### DIFF
--- a/announcements/_posts/2026-03-30-Improvement-of-the-search-bar.md
+++ b/announcements/_posts/2026-03-30-Improvement-of-the-search-bar.md
@@ -1,6 +1,6 @@
 ---
 title: "Improvements to Data Portal Search"
-pinned: true
+pinned: false
 ---
 
 We’ve improved the search bar in the [IGSR data portal](https://internationalgenome.org/data-portal/search). Search now does a better job of combining normal word matching with partial matching, so it is more likely to find what you expect whether you search by a full name, a shorter term, or part of an identifier.

--- a/announcements/_posts/2026-05-12-New-filter-query-builder.md
+++ b/announcements/_posts/2026-05-12-New-filter-query-builder.md
@@ -9,8 +9,6 @@ We have added a filtration query builder to the IGSR data portal to make it easi
 
 The filtration query builder lets you combine multiple filters, define inclusion/exclusion, add AND/OR operators, and control evaluation order with group/ungroup functionality. This should make it simpler to explore IGSR data and narrow results to find the data subsets of interest to you. See below for a quick demonstration.
 
-<img src="/announcements/images/filtration_query_builder_screen_cap.gif" alt='Demonstration of the filtration query builder' width="500">
-
-![Filtration query builder screen capture](/sites/1000genomes.org/files/images/filtration_query_builder_screen_cap.gif)
-
 You can try the query builder in the [IGSR data portal](https://internationalgenome.org/data-portal/sample).
+
+<img src="/announcements/images/filtration_query_builder_screen_cap.gif" alt='Demonstration of the filtration query builder' width="500">

--- a/announcements/_posts/2026-05-12-New-filter-query-builder.md
+++ b/announcements/_posts/2026-05-12-New-filter-query-builder.md
@@ -1,0 +1,16 @@
+---
+title: "New filtration query builder in the IGSR data portal"
+pinned: true
+---
+
+New feature announcement!
+
+We have added a filtration query builder to the IGSR data portal to make it easier to filter samples on population, data collection and sequencing technology.
+
+The filtration query builder lets you combine multiple filters, define inclusion/exclusion, add AND/OR operators, and control evaluation order with group/ungroup functionality. This should make it simpler to explore IGSR data and narrow results to find the data subsets of interest to you. See below for a quick demonstration.
+
+<img src="/announcements/images/filtration_query_builder_screen_cap.gif" alt='Demonstration of the filtration query builder' width="500">
+
+![Filtration query builder screen capture](/sites/1000genomes.org/files/images/filtration_query_builder_screen_cap.gif)
+
+You can try the query builder in the [IGSR data portal](https://internationalgenome.org/data-portal/sample).


### PR DESCRIPTION
See IGSR-637.

Should only be merged from June onwards to allow time for the current announcement (search improvements) to be pinned.

## Description

This PR adds an announcement about the filtration query builder with accompanying demo .gif. 

## Testing

You can view this on the test site at https://test.internationalgenome.org/. 