### PR TITLE
Remove superpopulation labels from website

### DIFF
--- a/_data-portal/app/population/population-detail.component.html
+++ b/_data-portal/app/population/population-detail.component.html
@@ -20,14 +20,6 @@
             <dt>Description:</dt>
             <dd>{{pop.description}}</dd>
           </ng-container>
-          <ng-container *ngIf="pop.superpopulation?.name">
-            <dt>Superpopulation:</dt>
-            <dd>{{pop.superpopulation.name}}</dd>
-          </ng-container>
-          <ng-container *ngIf="pop.superpopulation?.code">
-            <dt>Superpopulation code:</dt>
-            <dd>{{pop.superpopulation.code}}</dd>
-          </ng-container>
         </dl>
       </div>
     </div>
@@ -82,4 +74,3 @@
   </ng-container>
 
 </ng-container>
-

--- a/_data-portal/app/sample/sample-analysis-group-table.component.html
+++ b/_data-portal/app/sample/sample-analysis-group-table.component.html
@@ -45,8 +45,7 @@ Changes:
   <td class="capitalize">{{ hit._source.sex }}</td>
   <td>
 		<ng-container *ngFor="let pop of hit._source.populations">
-      <a *ngIf="pop.elasticId" [routerLink]="['/population', pop.elasticId]"
-     [popover]="pop.name" popoverPlacement="auto top" [popoverOnHover]="true">{{pop.description }}</a><br/>
+      <a *ngIf="pop.elasticId" [routerLink]="['/population', pop.elasticId]">{{pop.description }}</a><br/>
     </ng-container>
 	</td>
   <ng-container *ngFor="let ag of analysisGroupList?.hits">

--- a/_data-portal/app/sample/sample-data-collection-table.component.html
+++ b/_data-portal/app/sample/sample-data-collection-table.component.html
@@ -10,7 +10,8 @@
   <td class="capitalize">{{ hit._source.sex }}</td>
   <td>
 		<ng-container *ngFor="let pop of hit._source.populations">
-			<a *ngIf="pop.elasticId" [routerLink]="['/population', pop.elasticId]">{{pop.description }}</a><br/>
+			<a *ngIf="pop.elasticId" [routerLink]="['/population', pop.elasticId]"
+     [popover]="pop.name" popoverPlacement="auto top" [popoverOnHover]="true">{{pop.description }}</a><br/>
 		</ng-container>
 	</td>
   <td *ngFor="let dc of dataCollectionList?.hits">

--- a/_data-portal/app/sample/sample-data-collection-table.component.html
+++ b/_data-portal/app/sample/sample-data-collection-table.component.html
@@ -10,8 +10,7 @@
   <td class="capitalize">{{ hit._source.sex }}</td>
   <td>
 		<ng-container *ngFor="let pop of hit._source.populations">
-			<a *ngIf="pop.elasticId" [routerLink]="['/population', pop.elasticId]"
-     [popover]="pop.name" popoverPlacement="auto top" [popoverOnHover]="true">{{pop.description }}</a><br/>
+			<a *ngIf="pop.elasticId" [routerLink]="['/population', pop.elasticId]">{{pop.description }}</a><br/>
 		</ng-container>
 	</td>
   <td *ngFor="let dc of dataCollectionList?.hits">

--- a/_data-portal/app/sample/sample-detail.component.html
+++ b/_data-portal/app/sample/sample-detail.component.html
@@ -11,12 +11,12 @@
             <dt>Sex:</dt>
             <dd class="capitalize">{{sample.sex}}</dd>
           </ng-container>
-					<ng-container *ngIf="sample.populations">
-						<dt>Populations:</dt>
-    				<ng-container *ngFor="let pop of sample.populations">
-      				<dd><a [routerLink]="['/population', pop.elasticId]">{{pop.description}}</a>, {{pop.superpopulationName}}</dd>
-    				</ng-container>
-					</ng-container>
+          <ng-container *ngIf="sample.populations">
+            <dt>Populations:</dt>
+            <ng-container *ngFor="let pop of sample.populations">
+              <dd><a [routerLink]="['/population', pop.elasticId]">{{pop.description}}</a></dd>
+            </ng-container>
+          </ng-container>
           <ng-container *ngIf="sample.biosampleId">
             <dt>Biosample ID:</dt>
             <dd><a [href]="'http://www.ebi.ac.uk/biosamples/samples/' + sample.biosampleId" target="_blank">{{sample.biosampleId}}</a></dd>
@@ -104,4 +104,3 @@
   </data-collection-files>
   </ng-container>
 </ng-container>
-

--- a/_data-portal/app/shared/components/population-filter.component.html
+++ b/_data-portal/app/shared/components/population-filter.component.html
@@ -9,8 +9,7 @@
     <div class="filter-options-scroll">
       <div class="form filter-options-grid">
         <div class="checkbox" *ngFor="let pop of popHits?.hits">
-          <label *ngIf="pop._source.elasticId" [popover]="pop._source.superpopulation.name" [popoverOnHover]="true" popoverPlacement="auto bottom">
-          <!--<label *ngIf="pop._source.elasticId">-->
+          <label *ngIf="pop._source.elasticId">
                <input type="checkbox" [ngModel]="filters[pop._source.elasticId]" (ngModelChange)="changeFilter(pop._source.elasticId, $event)">
                {{pop._source.description}}
           </label>


### PR DESCRIPTION
See IGSR-639. 

## Description

This PR removes superpopulation from sample and population pages, as well as from the data portal hover-over (hovering over population labels would show superpopulation). 

## Testing

Compare new:
https://test.internationalgenome.org/data-portal/population/CEU
https://test.internationalgenome.org/data-portal/sample/HG00096 

With old: 
https://internationalgenome.org/data-portal/population/CEU
https://internationalgenome.org/data-portal/sample/HG00096 

And check population hover-over in data portal. 

