### PR TITLE
Fix for DC description boxes not showing up

### DIFF
--- a/_data-portal/app/core/services/api-data-collection.service.ts
+++ b/_data-portal/app/core/services/api-data-collection.service.ts
@@ -49,7 +49,8 @@ export class ApiDataCollectionService {
   }
 
   getText(id: string): Observable<string> {
-      return this.http.get(`/data-portal/data-collections/${id}.html`, {responseType: 'text'})
+      // Jekyll 4 emits each collection page as <id>/index.html.
+      return this.http.get(`/data-portal/data-collections/${id}/`, {responseType: 'text'})
         .catch((err, caught): Observable<any> => Observable.of<any>(null))
         .map((r: any): string => {
           let text: string = r ? r : ''


### PR DESCRIPTION
This PR fixes the absence of description boxes on DC pages. This has been deployed to test, see: https://test.internationalgenome.org/data-portal/data-collection.

## Description

The security PR upgraded Jekyll from v2 to v4. In Jekyll v2, `.md` description files are generated to `data-collections/phase3.html`, but in v4, they're generated into, for example, `data-collections/phase3/index.html`. So this PR requests the md via the new, updated path. 