### PR TITLE
Support links opening in new tabs rather than inplace

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,6 +15,7 @@
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+  <script src="{{ '/js/external-links.js' | relative_url }}" defer></script>
   
   
   

--- a/js/external-links.js
+++ b/js/external-links.js
@@ -1,0 +1,12 @@
+(function () {
+  "use strict";
+
+  document.addEventListener("click", function (event) {
+    var link = event.target.closest && event.target.closest("a[href]");
+
+    if (link && /^https?:$/.test(link.protocol) && link.host !== window.location.host) {
+      link.target = "_blank";
+      link.relList.add("noopener", "noreferrer");
+    }
+  });
+})();


### PR DESCRIPTION
IGSR-651

Addition of JS script to make external links open in new tabs rather than in place of the current IGSR window.  Live on the test site: https://test.internationalgenome.org/. 


